### PR TITLE
explicitely deduplicate advertisements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ Each device decoder must export:
    - `name` (optional): If specified, the BLE device name must match this for the decoder to apply
    - `manufacturer` (optional): If specified, the BLE manufacturer data must begin with this 2-byte manufacturer ID (in hex string form e.g. "9904")
    - `serviceUUID` (optional): If specified, advertisement must contain this service UUID to match (in hex string form e.g. "fcd2")
-   - `advertisementDecode` (optional): Function to decode BLE manufacturer data in advertisements
-   - `servicedataDecode` (optional): Function to decode service data in BLE advertisements if the `serviceUUID` matches
+   - `advertisementDecode` (optional): Function to decode BLE manufacturer or service data in advertisements
    - `start` (optional): Function called to start data collection from the device, typically for sending the command to start data streaming
    - `stop` (optional): Function to stop data collection, typically for sending the command to stop data streaming
    - `notify` (optional): Listeners to set up given a serviceUUID and characteristicUUID, these may return decoded data (or null when listening for other information, such as the device sensor scale factor)

--- a/devices/bthome.js
+++ b/devices/bthome.js
@@ -7,7 +7,8 @@
  * https://github.com/AlCalzone/ioBroker.ble.git
  * MIT license
  */
-function decodeBTHome(data) {
+function decodeBTHome(_manufacturerData, serviceData) {
+  let data = serviceData["fcd2"];
   if (
     data.length < 7 || // too short
     data[0] & 0x01 || // encrypted data not supported
@@ -516,7 +517,7 @@ export const decoder = {
   decoderName: "bthome",
   name: null,
   serviceUUID: "fcd2",
-  servicedataDecode: decodeBTHome,
+  advertisementDecode: decodeBTHome,
   units:
     "Values will be in the appropriate units based on documentation: https://bthome.io/format/",
 };
@@ -527,7 +528,7 @@ export const tests = [
     // servicedata decode test. Given the servicedata data, it should decode to the expected values.
     given: {
       // DIY sensor https://github.com/mhaberler/BTHomeV2-ESP32-example.git#9f34e42b9c3b039718b67da57ea02e7fa0d11417
-      serviceData: "403a013c020653034142435403313233",
+      serviceData: { fcd2: "403a013c020653034142435403313233" },
     },
     expected: {
       multilevelSensors: [],
@@ -544,7 +545,7 @@ export const tests = [
   },
   {
     given: {
-      serviceData: "40000902ac0d03a00f04f28f0105d91300100112b804",
+      serviceData: { fcd2: "40000902ac0d03a00f04f28f0105d91300100112b804" },
     },
     expected: {
       packetId: 9,
@@ -592,7 +593,7 @@ export const tests = [
   {
     given: {
       // idle Shelly BLU
-      serviceData: "4400ca01643a00",
+      serviceData: { fcd2: "4400ca01643a00" },
     },
     expected: {
       packetId: 202,
@@ -605,8 +606,9 @@ export const tests = [
   {
     given: {
       //  DIY sensor extended advertising with pid
-      serviceData:
-        "40004a03a00f04f28f015312424c41424c4164646164617364617358595a5403313233",
+      serviceData: {
+        fcd2: "40004a03a00f04f28f015312424c41424c4164646164617364617358595a5403313233",
+      },
     },
     expected: {
       packetId: 74,
@@ -625,8 +627,9 @@ export const tests = [
   {
     given: {
       //  DIY sensor extended advertising with pid and mac
-      serviceData:
-        "4248ca433932a5002f03a00f04f28f015312424c41424c4164646164617364617358595a5403313233",
+      serviceData: {
+        fcd2: "4248ca433932a5002f03a00f04f28f015312424c41424c4164646164617364617358595a5403313233",
+      },
     },
     expected: {
       packetId: 47,
@@ -646,8 +649,9 @@ export const tests = [
   {
     given: {
       //  DIY sensor extended advertising with pid and mac, lots of fields
-      serviceData:
-        "4248ca433932a5002c02ac0d03a00f04f28f0105d91300100112b804135e013a013c02065312424c41424c4164646164617364617358595a5403313233",
+      serviceData: {
+        fcd2: "4248ca433932a5002c02ac0d03a00f04f28f0105d91300100112b804135e013a013c02065312424c41424c4164646164617364617358595a5403313233",
+      },
     },
     expected: {
       packetId: 44,

--- a/harness/main.js
+++ b/harness/main.js
@@ -66,27 +66,19 @@ async function main() {
         logFoundDevice(peripheral.id, advertisement);
       } else if (isDecoderValid(decoder, advertisement)) {
         if (decoder.advertisementDecode) {
+          const serviceData = (advertisement.serviceData ?? []).reduce(
+            (acc, sd) => {
+              acc[sd.uuid] = sd.data;
+              return acc;
+            },
+            {}
+          );
           const decoded = decoder.advertisementDecode(
-            advertisement.manufacturerData
+            advertisement.manufacturerData,
+            serviceData
           );
           if (decoded) {
-            console.log(
-              "Got data from device:",
-              advertisement.manufacturerData.toString("hex")
-            );
-            console.log("Decoded data:", decoded);
-          }
-        }
-        if (decoder.servicedataDecode) {
-          const decoded = decoder.servicedataDecode(
-            advertisement.serviceData[0].data
-          );
-          if (decoded) {
-            console.log(
-              "Got data from device:",
-              advertisement.serviceData[0].data.toString("hex")
-            );
-            console.log("Decoded data:", decoded);
+            console.log("Decoded advertisement data:", decoded);
           }
         }
         if (decoder.start) {

--- a/harness/test.js
+++ b/harness/test.js
@@ -14,18 +14,10 @@ async function run() {
     }
     for (const test of tests) {
       const given = test.given;
-      if (
-        given.manufacturerData != null &&
-        decoder.advertisementDecode != null
-      ) {
+      if (decoder.advertisementDecode != null) {
         const decoded = decoder.advertisementDecode(
-          Buffer.from(given.manufacturerData, "hex")
-        );
-        logTest(test, decoder, decoded);
-      }
-      if (given.serviceData != null && decoder.servicedataDecode != null) {
-        const decoded = decoder.servicedataDecode(
-          Buffer.from(given.serviceData, "hex")
+          processManufacturerData(given.manufacturerData),
+          processServiceData(given.serviceData)
         );
         logTest(test, decoder, decoded);
       }
@@ -55,6 +47,24 @@ async function run() {
       }
     }
   }
+}
+
+function processManufacturerData(manufacturerData) {
+  if (manufacturerData == null) {
+    return manufacturerData;
+  }
+  return Buffer.from(manufacturerData, "hex");
+}
+
+function processServiceData(serviceData) {
+  if (serviceData == null) {
+    return serviceData;
+  }
+  const processed = {};
+  for (const [uuid, data] of Object.entries(serviceData)) {
+    processed[uuid] = Buffer.from(data, "hex");
+  }
+  return processed;
 }
 
 function logTest(test, decoder, decoded) {


### PR DESCRIPTION
### Description

I am positive scanning with scanDuplicates = false is fundamentally broken - the dup filter in the BLE stack doesnt do the right thing  for beacon type sensors

this is not a PR, just a proof of concept

- use scanDuplicates = true
- compare manufacturerdata and servicedata of an ad to the previous ad and only go ahead if changed

works on MacOS and Linux

