### PR TITLE
bthome: support device information decoding

### DIFF
--- a/devices/bthome.js
+++ b/devices/bthome.js
@@ -594,12 +594,13 @@ export const tests = [
       raw: "313233",
     },
   },
-  {
+  { // testcase from manual https://bthome.io/format/
     given: {
-      serviceData: { fcd2: "44f00100f128000000f21a0000" },
+      serviceData: { fcd2: "44f00100f100010204f2000106" },
     },
     expected: {
-      devicetype: 1, fwversion4: '40.0.0.0', fwversion3: '26.0.0'
+      devicetype: 1, fwversion4: '4.2.1.0', fwversion3: '6.1.0'
     },
   }
 ];
+

--- a/devices/bthome.js
+++ b/devices/bthome.js
@@ -98,17 +98,17 @@ function decodeBTHome(_manufacturerData, serviceData) {
       data = data.slice(3);
 
     } else if (objectId === 0xF1) { // firmware version, 	uint32 (4 bytes)
-      const major = data[1];
-      const minor = data[2];
-      const patch = data[3];
-      const rel = data[4];
+      const rel = data[1];
+      const patch = data[2];
+      const minor = data[3];
+      const major = data[4];
       result[`fwversion4`] = `${major}.${minor}.${patch}.${rel}`;
       data = data.slice(5);
 
     } else if (objectId === 0xF2) { // firmware version, uint24 (3 bytes)
-      const major = data[1];
+      const patch = data[1];
       const minor = data[2];
-      const patch = data[3];
+      const major = data[3];
       result[`fwversion3`] = `${major}.${minor}.${patch}`;
       data = data.slice(4);
     } else {
@@ -594,4 +594,12 @@ export const tests = [
       raw: "313233",
     },
   },
+  {
+    given: {
+      serviceData: { fcd2: "44f00100f128000000f21a0000" },
+    },
+    expected: {
+      devicetype: 1, fwversion4: '40.0.0.0', fwversion3: '26.0.0'
+    },
+  }
 ];

--- a/devices/bthome.js
+++ b/devices/bthome.js
@@ -92,6 +92,23 @@ function decodeBTHome(_manufacturerData, serviceData) {
       const value = data.slice(2, 2 + length);
       result.raw = value.toString("hex");
       data = data.slice(2 + length);
+    } else if (objectId === 0xF0) { // device type id, 	uint16 (2 bytes)
+      const devType = serviceData.getUint16(offset + 1);
+      decodedValue[`devicetype`] = devType;
+      offset += 2;
+    } else if (objectId === 0xF1) { // firmware version, 	uint32 (4 bytes)
+      const major = serviceData.getUint8(offset + 1);
+      const minor = serviceData.getUint8(offset + 2);
+      const patch = serviceData.getUint8(offset + 4);
+      const rel = serviceData.getUint8(offset + 3);
+      decodedValue[`fwversion4`] = `${major}.${minor}.${patch}.${rel}`;
+      offset += 4;
+    } else if (objectId === 0xF2) { // firmware version, uint24 (3 bytes)
+      const major = serviceData.getUint8(offset + 1);
+      const minor = serviceData.getUint8(offset + 2);
+      const patch = serviceData.getUint8(offset + 3);
+      decodedValue[`fwversion3`] = `${major}.${minor}.${patch}`;
+      offset += 3;
     } else {
       console.log(`Unsupported BTHome object ID ${objectId.toString(16)}`);
       return {};

--- a/devices/bthome.js
+++ b/devices/bthome.js
@@ -92,6 +92,25 @@ function decodeBTHome(_manufacturerData, serviceData) {
       const value = data.slice(2, 2 + length);
       result.raw = value.toString("hex");
       data = data.slice(2 + length);
+
+    } else if (objectId === 0xF0) { // device type id, 	uint16 (2 bytes)
+      result[`devicetype`] = data.readUInt16LE(1); // little endian);
+      data = data.slice(3);
+
+    } else if (objectId === 0xF1) { // firmware version, 	uint32 (4 bytes)
+      const major = data[1];
+      const minor = data[2];
+      const patch = data[3];
+      const rel = data[4];
+      result[`fwversion4`] = `${major}.${minor}.${patch}.${rel}`;
+      data = data.slice(5);
+
+    } else if (objectId === 0xF2) { // firmware version, uint24 (3 bytes)
+      const major = data[1];
+      const minor = data[2];
+      const patch = data[3];
+      result[`fwversion3`] = `${major}.${minor}.${patch}`;
+      data = data.slice(4);
     } else {
       console.log(`Unsupported BTHome object ID ${objectId.toString(16)}`);
       return {};

--- a/devices/bthome.js
+++ b/devices/bthome.js
@@ -10,7 +10,7 @@
 function decodeBTHome(_manufacturerData, serviceData) {
   let data = serviceData["fcd2"];
   if (
-    data.length < 7 || // too short
+    data.length < 4 || // too short
     data[0] & 0x01 || // encrypted data not supported
     (data[0] & 0x60) >> 5 != 2 // not BTHome v2
   ) {
@@ -92,23 +92,6 @@ function decodeBTHome(_manufacturerData, serviceData) {
       const value = data.slice(2, 2 + length);
       result.raw = value.toString("hex");
       data = data.slice(2 + length);
-    } else if (objectId === 0xF0) { // device type id, 	uint16 (2 bytes)
-      const devType = serviceData.getUint16(offset + 1);
-      decodedValue[`devicetype`] = devType;
-      offset += 2;
-    } else if (objectId === 0xF1) { // firmware version, 	uint32 (4 bytes)
-      const major = serviceData.getUint8(offset + 1);
-      const minor = serviceData.getUint8(offset + 2);
-      const patch = serviceData.getUint8(offset + 4);
-      const rel = serviceData.getUint8(offset + 3);
-      decodedValue[`fwversion4`] = `${major}.${minor}.${patch}.${rel}`;
-      offset += 4;
-    } else if (objectId === 0xF2) { // firmware version, uint24 (3 bytes)
-      const major = serviceData.getUint8(offset + 1);
-      const minor = serviceData.getUint8(offset + 2);
-      const patch = serviceData.getUint8(offset + 3);
-      decodedValue[`fwversion3`] = `${major}.${minor}.${patch}`;
-      offset += 3;
     } else {
       console.log(`Unsupported BTHome object ID ${objectId.toString(16)}`);
       return {};


### PR DESCRIPTION
### Description

see https://bthome.io/format/ section Device information

seen in the wild, unfortunately no test yet

### Checklist

- [ x] I have tested my changes on a real device
- [x ] I have included at least one test (if adding a new decoder)
- [ x] I have reviewed and accept the [Contributor License Agreement (CLA)](https://github.com/tszheichoi/sensor-ble/blob/main/CLA.md)
