### PR TITLE
bthome: accel, speed: switch to int32_t scaled by 1e-6

### DIFF
--- a/devices/bthome.js
+++ b/devices/bthome.js
@@ -129,6 +129,14 @@ const multilevelSensorsArray = [
     unit: "m/s²",
   },
   {
+    id: 0x63,
+    label: "acceleration",
+    signed: true,
+    size: 4,
+    factor: 0.000001,
+    unit: "m/s²",
+  },
+  {
     id: 0x01,
     label: "battery",
     signed: false,
@@ -322,6 +330,14 @@ const multilevelSensorsArray = [
     signed: false,
     size: 2,
     factor: 0.01,
+    unit: "m/s",
+  },
+  {
+    id: 0x62,
+    label: "speed",
+    signed: true,
+    size: 4,
+    factor: 0.000001,
     unit: "m/s",
   },
   {
@@ -601,6 +617,16 @@ export const tests = [
     expected: {
       devicetype: 1, fwversion4: '4.2.1.0', fwversion3: '6.1.0'
     },
-  }
+  },
+  { // test signed speed and acceleration
+    given: {
+      serviceData: { fcd2: "40624099dfff630057d0ff" },
+    },
+    expected: {
+      'speed_m/s': -2.123456, 'acceleration_m/s²': -3.123456
+    }
+  },
+
+
 ];
 


### PR DESCRIPTION
includes testcases

### Description

add signed speed and acceleration types
https://github.com/Bluetooth-Devices/bthome-ble/releases/tag/v3.16.0
https://github.com/Bluetooth-Devices/bthome-ble/commit/c3da4f40205dc2174757593c7605a9d256252bc5#diff-4e5abc42cb43cb60ff2cfaa98232bc23c17c0d100e5373bb8d85d48c76d5007f

### Checklist

- [ x] I have tested my changes on a real device
- [x ] I have included at least one test (if adding a new decoder)
- [ x] I have reviewed and accept the [Contributor License Agreement (CLA)](https://github.com/tszheichoi/sensor-ble/blob/main/CLA.md)
