### PR TITLE
bthome: fix missing object id's

### DIFF
--- a/devices/bthome.js
+++ b/devices/bthome.js
@@ -12,7 +12,7 @@ function decodeBTHome(_manufacturerData, serviceData) {
   if (
     data.length < 4 || // too short
     data[0] & 0x01 || // encrypted data not supported
-    (data[0] & 0x60) >> 5 != 2 // not BTHome v2
+    (data[0] & 0xe0) >> 5 != 2 // not BTHome v2
   ) {
     return null;
   }
@@ -56,15 +56,16 @@ function decodeBTHome(_manufacturerData, serviceData) {
       // button event
       const eventId = data[1];
       if (eventId !== 0x00) {
-        const event = [
-          "press",
-          "double_press",
-          "triple_press",
-          "long_press",
-          "long_double_press",
-          "long_triple_press",
-        ][eventId - 1];
-        result.button = event;
+        const buttonEvents = {
+          0x01: "press",
+          0x02: "double_press",
+          0x03: "triple_press",
+          0x04: "long_press",
+          0x05: "long_double_press",
+          0x06: "long_triple_press",
+          0x80: "hold_press",
+        };
+        result.button = buttonEvents[eventId];
       }
       data = data.slice(2);
     } else if (objectId === 0x3c) {
@@ -425,6 +426,79 @@ const multilevelSensorsArray = [
     factor: 0.001,
     unit: "L",
   },
+  {
+    id: 0x55,
+    label: "volume storage",
+    signed: false,
+    size: 4,
+    factor: 0.001,
+    unit: "L",
+  },
+  {
+    id: 0x56,
+    label: "conductivity",
+    signed: false,
+    size: 2,
+    unit: "µS/cm",
+  },
+  {
+    id: 0x57,
+    label: "temperature",
+    signed: true,
+    size: 1,
+    unit: "C",
+  },
+  {
+    id: 0x58,
+    label: "temperature",
+    signed: true,
+    size: 1,
+    factor: 0.35,
+    unit: "C",
+  },
+  { id: 0x59, label: "count", signed: true, size: 1 },
+  { id: 0x5a, label: "count", signed: true, size: 2 },
+  { id: 0x5b, label: "count", signed: true, size: 4 },
+  {
+    id: 0x5c,
+    label: "power",
+    signed: true,
+    size: 4,
+    factor: 0.01,
+    unit: "W",
+  },
+  {
+    id: 0x5d,
+    label: "current",
+    signed: true,
+    size: 2,
+    factor: 0.001,
+    unit: "A",
+  },
+  {
+    id: 0x5e,
+    label: "direction",
+    signed: false,
+    size: 2,
+    factor: 0.01,
+    unit: "°",
+  },
+  {
+    id: 0x5f,
+    label: "precipitation",
+    signed: false,
+    size: 2,
+    factor: 0.1,
+    unit: "mm",
+  },
+  { id: 0x60, label: "channel", signed: false, size: 1 },
+  {
+    id: 0x61,
+    label: "rotational speed",
+    signed: false,
+    size: 2,
+    unit: "rpm",
+  },
 ];
 const multilevelSensorDefinitions = new Map(
   multilevelSensorsArray.map((def) => [def.id, def])
@@ -626,7 +700,18 @@ export const tests = [
       'speed_m/s': -2.123456, 'acceleration_m/s²': -3.123456
     }
   },
-
+  { // shelly window sensor
+    given: {
+      serviceData: { fcd2: "4400f00164055802002d003f0000" },
+    },
+    expected: {
+      packetId: 240,
+      battery_percent: 100,
+      illuminance_lux: 6,
+      window: false,
+      'rotation_°': 0
+    }
+  },
 
 ];
 


### PR DESCRIPTION
Shelly Window sensor decodes properly now.


Claude Opus 4.6 had a go at it:

User: study the sensor data at https://bthome.io/format/ add any missing  sensors
fix any errors

GitHub Copilot:

Fetched https://bthome.io/format/

Read [](file:///Users/mah/Ballon/src/BalloonWare/sensor-ble/devices/bthome.js#1-1), lines 1 to 500

Read [](file:///Users/mah/Ballon/src/BalloonWare/sensor-ble/devices/bthome.js#500-500), lines 500 to 644

Created 5 todos

Read [](file:///Users/mah/Ballon/src/BalloonWare/sensor-ble/harness/test.js#1-1), lines 1 to 80

Starting: *Fix version check bitmask* (1/5)

Now I have a clear picture. Here's what I found:

**Missing sensors (13):** `0x55` volume storage, `0x56` conductivity, `0x57` temperature (sint8, factor 1), `0x58` temperature (sint8, factor 0.35), `0x59`/`0x5A`/`0x5B` signed counts, `0x5C` signed power, `0x5D` signed current, `0x5E` direction, `0x5F` precipitation, `0x60` channel, `0x61` rotational speed

**Bugs:**
1. Version check uses mask `0x60` (bits 5-6) instead of `0xe0` (bits 5-7) — works for v2 by coincidence but wrong per spec
2. Button event handler uses array indexing which can't handle `0x80` (hold_press)
3. Test expected `illuminance_lux: 6` should be `6.4` based on the test data

Replacing 28 lines with 102 lines in [](file:///Users/mah/Ballon/src/BalloonWare/sensor-ble/devices/bthome.js)

```

```

Starting: *Test the changes* (5/5)

Ran terminal command:  node harness/test.js

Interesting — the actual decoding gives 6, not 6.4. Let me recheck the test data more carefully.

Read [](file:///Users/mah/Ballon/src/BalloonWare/sensor-ble/devices/bthome.js#620-620), lines 620 to 635

Searched for text `shelly window sensor` (`**/devices/bthome.js`), 1 result

Read [](file:///Users/mah/Ballon/src/BalloonWare/sensor-ble/devices/bthome.js#703-703), lines 703 to 718

I misread the hex earlier — the data is `055802` not `058002`, so the illuminance value is indeed 600 × 0.01 = 6. The original expected was correct. Let me revert that.

Replacing 2 lines with 2 lines in [](file:///Users/mah/Ballon/src/BalloonWare/sensor-ble/devices/bthome.js)

```

```

Ran terminal command:  node harness/test.js

All tests pass. Let me update the todo list.

Completed: *Test the changes* (5/5)

All tests pass. Here's a summary of the changes to bthome.js:

**Bug fixes:**
- **Version check bitmask**: Changed `0x60` → `0xe0` to correctly mask all 3 bits (5-7) of the BTHome version field. The old mask only checked bits 5-6, which happened to work for v2 but would fail for future versions ≥ 4.
- **Button hold_press**: Replaced array-index lookup with a map object, adding the missing `0x80` → `"hold_press"` event. The old array approach would produce `undefined` for event ID `0x80`.

**13 missing sensors added:**

| ID | Sensor | Type | Factor | Unit |
|----|--------|------|--------|------|
| `0x55` | volume storage | uint32 | 0.001 | L |
| `0x56` | conductivity | uint16 | 1 | µS/cm |
| `0x57` | temperature | sint8 | 1 | °C |
| `0x58` | temperature | sint8 | 0.35 | °C |
| `0x59` | count | sint8 | 1 | — |
| `0x5A` | count | sint16 | 1 | — |
| `0x5B` | count | sint32 | 1 | — |
| `0x5C` | power (signed) | sint32 | 0.01 | W |
| `0x5D` | current (signed) | sint16 | 0.001 | A | | `0x5E` | direction | uint16 | 0.01 | ° |
| `0x5F` | precipitation | uint16 | 0.1 | mm |
| `0x60` | channel | uint8 | 1 | — |
| `0x61` | rotational speed | uint16 | 1 | rpm |

Made changes.

### Description

<!-- Please include a summary of the change -->

### Checklist

- [x] I have tested my changes on a real device
- [x] I have included at least one test (if adding a new decoder)
- [x] I have reviewed and accept the [Contributor License Agreement (CLA)](https://github.com/tszheichoi/sensor-ble/blob/main/CLA.md)
